### PR TITLE
Bug found and fixed: When using the psudos selector :parent without p…

### DIFF
--- a/pseudo-cheerio.js
+++ b/pseudo-cheerio.js
@@ -82,7 +82,12 @@ function find($, query, context, extra_pseudos) {
           context = $(context);
         }
 
-        context = fn(context, ...args);
+				if (args) {
+					context = fn(context, ...args);
+				} else {
+					context = fn(context, null);
+				}
+
         updated_context = true;
         break;
       case 2: // pseudo-class arg (ignore)


### PR DESCRIPTION
Passing the args using the spread syntax on an empty array caused an error in cheerio's traversing.js: causing match to be undefined in makeFilterMethod fn.

**Summary of Error:**
\node_modules\cheerio\lib\api\traversing.js:322
    } else if (match.cheerio) {
                    ^

TypeError: Cannot read property 'cheerio' of undefined
    at Array.<anonymous> (C:\Users\Chris\Projects\x\node_modules\cheerio\lib\api\traversing.js:322:21)
    at initialize.exports.parent (C:\Users\Chris\Projects\x\node_modules\cheerio\lib\api\traversing.js:56:26)
    at parent (C:\Users\Chris\Projects\x\node_modules\pseudo-cheerio\pseudo-cheerio.js:12:25)
    at sp.forEach (C:\Users\Chris\Projects\x\node_modules\pseudo-cheerio\pseudo-cheerio.js:88:19)
    at Array.forEach (<anonymous>)
    at Object.find (C:\Users\Chris\Projects\x\node_modules\pseudo-cheerio\pseudo-cheerio.js:56:6)
    at IncomingMessage.<anonymous> (C:\Users\Chris\Projects\x\get-annotations.js:61:12)
    at emitNone (events.js:110:20)
    at IncomingMessage.emit (events.js:207:7)
    at endReadableNT (_stream_readable.js:1059:12)